### PR TITLE
Move from .bind() to .on()

### DIFF
--- a/lib/flight-jasmine.js
+++ b/lib/flight-jasmine.js
@@ -194,7 +194,7 @@ jasmine.flight = {};
         eventsData.spiedEvents[[selector, eventName]].calls.push(call);
         eventsData.spiedEvents[[selector, eventName]].mostRecentCall = call;
       };
-      jQuery(selector).bind(eventName, handler);
+      jQuery(selector).on(eventName, handler);
       eventsData.handlers.push(handler);
       return eventsData.spiedEvents[[selector, eventName]];
     },


### PR DESCRIPTION
In jQuery 2.0 `bind()` has been moved into a separate event-alias module and when using a custom jQuery build without it, flight-jasmine breaks.

`bind()` has been deprecated [and calls `.on()` anyway](https://github.com/jquery/jquery/blob/master/src/event-alias.js#L18).

Details here - http://bugs.jquery.com/ticket/13554
