### PR TITLE
Clean up event spy data and detach handlers after each spec

### DIFF
--- a/lib/flight-jasmine.js
+++ b/lib/flight-jasmine.js
@@ -195,7 +195,7 @@ jasmine.flight = {};
         eventsData.spiedEvents[[selector, eventName]].mostRecentCall = call;
       };
       jQuery(selector).on(eventName, handler);
-      eventsData.handlers.push(handler);
+      eventsData.handlers.push([selector, eventName, handler]);
       return eventsData.spiedEvents[[selector, eventName]];
     },
 
@@ -244,6 +244,10 @@ jasmine.flight = {};
 
     cleanUp: function() {
       eventsData.spiedEvents = {};
+      // unbind all handlers
+      for(var i = 0; i < eventsData.handlers.length; i++) {
+        jQuery(eventsData.handlers[i][0]).off(eventsData.handlers[i][1], eventsData.handlers[i][2]);
+      }
       eventsData.handlers    = [];
     }
   };
@@ -382,6 +386,9 @@ beforeEach(function() {
       return result;
     }
   });
+});
+afterEach(function() {
+  jasmine.flight.events.cleanUp();
 });
 
 var spyOnEvent = function(selector, eventName) {


### PR DESCRIPTION
Multiple calls to `spyOnEvent` where the selector/event pair create the
same hash will share event data between the spies. Additionally, event
handlers bound for these spies are never detached, so subsequent specs
can cause previously-bound spies to fire again. This does not affect the
most recent call, but does affect the call count; event data is stored
multiple times, once for each spy bound.

Binding spies now stores the "selector" (or possibly HTMLElement) along
with the event name to correctly detach event spy handlers via
`jasmine.flight.events.cleanUp()`, and registers this function to run
after each spec.

Reproduction steps:

``` javascript
describe("someComponent", function() {
    it("should listen for an arbitrary event", function() {
        var innocuousSpy = spyOnEvent(document, 'event');
        $(document).trigger('event');
        expect(innocuousSpy.callCount).toBe(1);
    });
    it("should do something else with that event, too", function() {
        var misbehavingSpy = spyOnEvent(document, 'event');
        $(document).trigger('event');
        expect(misbehavingSpy.callCount).toBe(1); // fails; callCount is 2
    });
});
```

Fiddle: http://jsfiddle.net/scottrabin/tLEzf/1/
