### PR TITLE
Fixes the grunt-template-jasmine-requirejs at 0.1.0.

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -5,6 +5,6 @@
     "grunt": "~0.4.0",
     "grunt-contrib-jasmine": "0.4.2",
     "phantomjs": "1.8.1-1",
-    "grunt-template-jasmine-requirejs": "~0.1.0"
+    "grunt-template-jasmine-requirejs": "0.1.0"
   }
 }


### PR DESCRIPTION
Later versions of this template include RequireJS before the "vendor" JS libraries, which causes the es5-shim file to fail to load with a "Mismatched anonymous define() module" error.

Without this, the tests completely fail to run.
