### PR TITLE
Fixes toBeTriggeredOnAndWith.

### DIFF
--- a/lib/jasmine-flight.js
+++ b/lib/jasmine-flight.js
@@ -370,7 +370,8 @@
         var selector = arguments[0];
         var expectedArg = arguments[1];
         var exactMatch = !arguments[2];
-        var wasTriggered = jasmine.flight.events.wasTriggered(selector, this.actual);
+        var eventName = typeof this.actual === 'string' ? this.actual : this.actual.name;
+        var wasTriggered = jasmine.flight.events.wasTriggered(selector, eventName);
 
         this.message = function () {
           var $pp = function (obj) {
@@ -395,15 +396,15 @@
           };
 
           if (wasTriggered) {
-            var actualArg = jasmine.flight.events.eventArgs(selector, this.actual, expectedArg)[1];
+            var actualArg = jasmine.flight.events.eventArgs(selector, eventName, expectedArg)[1];
             return [
-              '<div class="value-mismatch">Expected event ' + this.actual.name + ' to have been triggered on' + selector,
-              '<div class="value-mismatch">Expected event ' + this.actual.name + ' not to have been triggered on' + selector
+              '<div class="value-mismatch">Expected event ' + eventName + ' to have been triggered on' + selector,
+              '<div class="value-mismatch">Expected event ' + eventName + ' not to have been triggered on' + selector
             ];
           } else {
             return [
-              'Expected event ' + this.actual.name + ' to have been triggered on ' + $pp(selector),
-              'Expected event ' + this.actual.name + ' not to have been triggered on ' + $pp(selector)
+              'Expected event ' + eventName + ' to have been triggered on ' + $pp(selector),
+              'Expected event ' + eventName + ' not to have been triggered on ' + $pp(selector)
             ];
           }
         };
@@ -413,9 +414,9 @@
         }
 
         if (exactMatch) {
-          return jasmine.flight.events.wasTriggeredWith(selector, this.actual, expectedArg, this.env);
+          return jasmine.flight.events.wasTriggeredWith(selector, eventName, expectedArg, this.env);
         } else {
-          return jasmine.flight.events.wasTriggeredWithData(selector, this.actual, expectedArg, this.env);
+          return jasmine.flight.events.wasTriggeredWithData(selector, eventName, expectedArg, this.env);
         }
       },
 

--- a/test/spec/spy-on-event.spec.js
+++ b/test/spec/spy-on-event.spec.js
@@ -59,4 +59,19 @@ define(function (require) {
     });
 
   });
+
+  describe('event matchers', function() {
+    beforeEach(function() {
+      this.spy = spyOnEvent(document, 'test-event');
+      $(document).trigger('test-event', {test: true});
+    });
+
+    it('matches with toHaveBeenTriggeredOn', function() {
+      expect(this.spy).toHaveBeenTriggeredOn(document);
+    });
+
+    it('matches with toHaveBeenTriggeredOnAndWith', function() {
+      expect(this.spy).toHaveBeenTriggeredOnAndWith(document, {test: true});
+    });
+  });
 });


### PR DESCRIPTION
This method expected its "actual" to sometimes be an event name and sometimes be a event or spy itself. Copies over the "eventName" convention from "toBeTriggeredOn."

Adds a small regression test.

Note that this requires the tests to run. For that see #12.
