### PR TITLE
Fix null values causing validateHash to fail

### DIFF
--- a/lib/jasmine-flight.js
+++ b/lib/jasmine-flight.js
@@ -307,7 +307,7 @@
       var validHash;
       for (var field in a) {
         if ((typeof a[field] === 'object') && (typeof b[field] === 'object')) {
-          validHash = jasmine.flight.validateHash(a[field], b[field]);
+          validHash = a[field] === b[field] || jasmine.flight.validateHash(a[field], b[field]);
         } else if (intersection && (typeof a[field] === 'undefined' || typeof b[field] === 'undefined')) {
           validHash = true;
         } else {

--- a/test/spec/spy-on-event.spec.js
+++ b/test/spec/spy-on-event.spec.js
@@ -57,7 +57,7 @@ define(function (require) {
   describe('event matchers', function () {
     beforeEach(function () {
       this.spy = spyOnEvent(document, 'test-event');
-      $(document).trigger('test-event', {test: true});
+      $(document).trigger('test-event', {test: true, test2: null});
     });
 
     it('matches with toHaveBeenTriggeredOn', function () {
@@ -65,7 +65,12 @@ define(function (require) {
     });
 
     it('matches with toHaveBeenTriggeredOnAndWith', function () {
-      expect(this.spy).toHaveBeenTriggeredOnAndWith(document, {test: true});
+      expect(this.spy).toHaveBeenTriggeredOnAndWith(document, {test: true, test2: null});
+    });
+
+    it('matches with data subset when nonexact flag is set', function () {
+      expect(this.spy).toHaveBeenTriggeredOnAndWith(document, {test: true}, true);
+      expect(this.spy).toHaveBeenTriggeredOnAndWith(document, {test2: null}, true);
     });
   });
 });


### PR DESCRIPTION
Take `validateHash({x:null, x:null})` as an example. As `null` has a
type of `object`, it would attempt to treat the null values as hashes
and recurse. Since `null` doesn't have any iterable fields, the validation
would then fail.

Fixed by adding a simple strict equality shortcut to prevent recursion
in this case.
