### PR TITLE
made document.documentElement, document, and window possible for compone...

### DIFF
--- a/lib/jasmine-flight.js
+++ b/lib/jasmine-flight.js
@@ -160,20 +160,45 @@
   };
 
   jasmine.Spec.prototype.setupComponent = function (fixture, options) {
+
+    // if node is explicitly passed as node
+    // do not append it to the body
+    // same is if it's the global object
+    var shouldNotAppend = (
+      typeof Node !== 'undefined' ?
+        fixture instanceof Node :
+        // fallback for IE < 9
+        'attachEvent' in fixture
+      ) || fixture === window
+    ;
+
     if (this.component) {
       this.component.teardown();
       this.$node.remove();
     }
 
-    if (fixture instanceof jQuery || typeof fixture === 'string') {
-      this.$node = $(fixture).addClass('component-root');
-    } else {
-      this.$node = $('<div class="component-root" />');
-      options = fixture;
-      fixture = null;
-    }
+    if (shouldNotAppend) {
 
-    $('body').append(this.$node);
+      // create a wrapper only if not global
+     this.$node = fixture === window ? [window] : $(fixture);
+     // if it was **not** the document
+     if (fixture.nodeType !== 9) {
+       this.$node.addClass('component-root');
+     }
+
+    } else {
+
+      if (fixture instanceof jQuery || typeof fixture === 'string') {
+        this.$node = $(fixture).addClass('component-root');
+      } else {
+        this.$node = $('<div class="component-root" />');
+        options = fixture;
+        fixture = null;
+      }
+
+      $('body').append(this.$node);
+
+    }
 
     options = options === undefined ? {} : options;
 


### PR DESCRIPTION
...nts

this is a working/tested solution for [this topic](https://github.com/flightjs/jasmine-flight/issues/27)

``` javascript
  beforeEach(function () {
    setupComponent(
      document.documentElement
    );
  });
```

Works like a charm for me in Safari, Firefox, and Chrome.
