### PR TITLE
Add toHaveBeenTriggeredOnAndWithFuzzy method

### DIFF
--- a/lib/jasmine-flight.js
+++ b/lib/jasmine-flight.js
@@ -343,6 +343,58 @@
       }
       return validHash;
     };
+
+    namespace.assertEventTriggeredWithData = function (selector, expectedArg, fuzzyMatch) {
+        var eventName = typeof this.actual === 'string' ? this.actual : this.actual.name;
+        var wasTriggered = jasmine.flight.events.wasTriggered(selector, eventName);
+
+        this.message = function () {
+          var $pp = function (obj) {
+            var description;
+            var attr;
+
+            if (!(obj instanceof jQuery)) {
+              obj = $(obj);
+            }
+
+            description = [
+              obj.get(0).nodeName
+            ];
+
+            attr = obj.get(0).attributes || [];
+
+            for (var x = 0; x < attr.length; x++) {
+              description.push(attr[x].name + '="' + attr[x].value + '"');
+            }
+
+            return '<' + description.join(' ') + '>';
+          };
+
+          if (wasTriggered) {
+            var actualArg = jasmine.flight.events.eventArgs(selector, eventName, expectedArg)[1];
+            return [
+              '<div class="value-mismatch">Expected event ' + eventName + ' to have been triggered on' + selector,
+              '<div class="value-mismatch">Expected event ' + eventName + ' not to have been triggered on' + selector
+            ];
+          } else {
+            return [
+              'Expected event ' + eventName + ' to have been triggered on ' + $pp(selector),
+              'Expected event ' + eventName + ' not to have been triggered on ' + $pp(selector)
+            ];
+          }
+        };
+
+        if (!wasTriggered) {
+          return false;
+        }
+
+        if (fuzzyMatch) {
+          return jasmine.flight.events.wasTriggeredWithData(selector, eventName, expectedArg, this.env);
+        } else {
+          return jasmine.flight.events.wasTriggeredWith(selector, eventName, expectedArg, this.env);
+        }
+
+    };
   })(jasmine.flight);
 
   beforeEach(function () {
@@ -390,58 +442,12 @@
         return wasTriggered;
       },
 
-      toHaveBeenTriggeredOnAndWith: function () {
-        var selector = arguments[0];
-        var expectedArg = arguments[1];
-        var exactMatch = !arguments[2];
-        var eventName = typeof this.actual === 'string' ? this.actual : this.actual.name;
-        var wasTriggered = jasmine.flight.events.wasTriggered(selector, eventName);
+      toHaveBeenTriggeredOnAndWith: function (selector, expectedArg, fuzzyMatch) {
+        return jasmine.flight.assertEventTriggeredWithData.call(this, selector, expectedArg, fuzzyMatch);
+      },
 
-        this.message = function () {
-          var $pp = function (obj) {
-            var description;
-            var attr;
-
-            if (!(obj instanceof jQuery)) {
-              obj = $(obj);
-            }
-
-            description = [
-              obj.get(0).nodeName
-            ];
-
-            attr = obj.get(0).attributes || [];
-
-            for (var x = 0; x < attr.length; x++) {
-              description.push(attr[x].name + '="' + attr[x].value + '"');
-            }
-
-            return '<' + description.join(' ') + '>';
-          };
-
-          if (wasTriggered) {
-            var actualArg = jasmine.flight.events.eventArgs(selector, eventName, expectedArg)[1];
-            return [
-              '<div class="value-mismatch">Expected event ' + eventName + ' to have been triggered on' + selector,
-              '<div class="value-mismatch">Expected event ' + eventName + ' not to have been triggered on' + selector
-            ];
-          } else {
-            return [
-              'Expected event ' + eventName + ' to have been triggered on ' + $pp(selector),
-              'Expected event ' + eventName + ' not to have been triggered on ' + $pp(selector)
-            ];
-          }
-        };
-
-        if (!wasTriggered) {
-          return false;
-        }
-
-        if (exactMatch) {
-          return jasmine.flight.events.wasTriggeredWith(selector, eventName, expectedArg, this.env);
-        } else {
-          return jasmine.flight.events.wasTriggeredWithData(selector, eventName, expectedArg, this.env);
-        }
+      toHaveBeenTriggeredOnAndWithFuzzy: function (selector, expectedArg) {
+        return jasmine.flight.assertEventTriggeredWithData.call(this, selector, expectedArg, true);
       },
 
       toHaveCss: function (prop, val) {

--- a/test/spec/spy-on-event.spec.js
+++ b/test/spec/spy-on-event.spec.js
@@ -68,9 +68,14 @@ define(function (require) {
       expect(this.spy).toHaveBeenTriggeredOnAndWith(document, {test: true, test2: null});
     });
 
-    it('matches with data subset when nonexact flag is set', function () {
+    it('matches with data subset when fuzzy flag is set', function () {
       expect(this.spy).toHaveBeenTriggeredOnAndWith(document, {test: true}, true);
       expect(this.spy).toHaveBeenTriggeredOnAndWith(document, {test2: null}, true);
+    });
+
+    it('matches with data subset when using fuzzy shortcut', function () {
+      expect(this.spy).toHaveBeenTriggeredOnAndWithFuzzy(document, {test: true});
+      expect(this.spy).toHaveBeenTriggeredOnAndWithFuzzy(document, {test2: null});
     });
   });
 });


### PR DESCRIPTION
The `exactMatch` parameter is currently undocumented and very hard to see in a
test. Exposing this behavior as seperate method makes the difference more
obvious.
