### PR TITLE
Update event spy `calls` with jasmine `CallTracker`

### DIFF
--- a/lib/jasmine-flight.js
+++ b/lib/jasmine-flight.js
@@ -251,9 +251,7 @@
     namespace.events = {
       spyOn: function (selector, eventName) {
         eventsData.spiedEvents[[selector, eventName]] = {
-          callCount: 0,
-          calls: [],
-          mostRecentCall: {},
+          calls: new jasmine.CallTracker(),
           name: eventName
         };
 
@@ -263,9 +261,7 @@
             args: jasmine.util.argsToArray(arguments),
             data: data
           };
-          eventsData.spiedEvents[[selector, eventName]].callCount++;
-          eventsData.spiedEvents[[selector, eventName]].calls.push(call);
-          eventsData.spiedEvents[[selector, eventName]].mostRecentCall = call;
+          eventsData.spiedEvents[[selector, eventName]].calls.track(call);
         };
 
         jQuery(selector).on(eventName, handler);
@@ -274,7 +270,7 @@
       },
 
       eventArgs: function (selector, eventName, expectedArg) {
-        var actualArgs = eventsData.spiedEvents[[selector, eventName]].mostRecentCall.args;
+        var actualArgs = eventsData.spiedEvents[[selector, eventName]].calls.mostRecent().args;
 
         if (!actualArgs) {
           throw 'No event spy found on ' + eventName + '. Try adding a call to spyOnEvent or make sure that the selector the event is triggered on and the selector being spied on are correct.';
@@ -294,7 +290,7 @@
 
       wasTriggered: function (selector, event) {
         var spiedEvent = eventsData.spiedEvents[[selector, event]];
-        return spiedEvent && spiedEvent.callCount > 0;
+        return spiedEvent && spiedEvent.calls.count() > 0;
       },
 
       wasTriggeredWith: function (selector, eventName, expectedArg) {

--- a/test/spec/spy-on-event.spec.js
+++ b/test/spec/spy-on-event.spec.js
@@ -7,8 +7,8 @@ define(function (require) {
     it('returns a spy', function () {
       var spy = spyOnEvent(document, 'test-event');
       expect(spy).not.toBeUndefined();
-      expect(spy.callCount).toBe(0);
-      expect(spy.mostRecentCall).toEqual({});
+      expect(spy.calls.count()).toBe(0);
+      expect(spy.calls.all()).toEqual([]);
     });
 
     it('records event when event is triggered on target element', function () {
@@ -18,19 +18,19 @@ define(function (require) {
         test: true
       });
 
-      // callcount should be incremented
-      expect(spy.callCount).toBe(1);
+      // calls.count() should be incremented
+      expect(spy.calls.count()).toBe(1);
 
-      // `mostRecentCall` should provide access to event data
-      expect(spy.mostRecentCall.data).toEqual({
+      // `calls.mostRecent()` should provide access to event data
+      expect(spy.calls.mostRecent().data).toEqual({
         test: true
       });
 
-      // `mostRecentCall` should provide access to all event args
-      expect(spy.mostRecentCall.args[0].type).toEqual('test-event');
+      // `calls.mostRecent()` should provide access to all event args
+      expect(spy.calls.mostRecent().args[0].type).toEqual('test-event');
 
       // calls should be exposed as array
-      expect(spy.calls[0]).toBe(spy.mostRecentCall);
+      expect(spy.calls.first()).toBe(spy.calls.mostRecent());
     });
 
     it('does not record event when event is triggered on different DOM branch', function () {
@@ -41,7 +41,7 @@ define(function (require) {
       $(document.body).trigger('test-event');
 
       // spy should not have been called
-      expect(spy.callCount).toBe(0);
+      expect(spy.calls.count()).toBe(0);
     });
 
     it('clears up after each test', function () {
@@ -49,8 +49,8 @@ define(function (require) {
 
       $(document).trigger('test-event');
 
-      // callcount should be 1
-      expect(spy.callCount).toBe(1);
+      // calls.count() should be 1
+      expect(spy.calls.count()).toBe(1);
     });
   });
 


### PR DESCRIPTION
This is to match the spy interface provided by Jasmine 2.0.
- Deprecate `callCount` for `calls.count()`
- Deprecate `mostRecentCall` for `calls.mostRecent()`

Fixes #52
