### PR TITLE
Improve error messaging

### DIFF
--- a/lib/jasmine-flight.js
+++ b/lib/jasmine-flight.js
@@ -385,17 +385,13 @@
           return '<' + description.join(' ') + '>';
         };
 
-        if (wasTriggered) {
-          var actualArg = jasmine.flight.events.eventArgs(selector, eventName, expectedArg)[1];
-          return [
-            '<div class="value-mismatch">Expected event ' + eventName + ' to have been triggered on' + selector,
-            '<div class="value-mismatch">Expected event ' + eventName + ' not to have been triggered on' + selector
-          ];
+        if (!wasTriggered) {
+          return 'Expected event ' + eventName + (result.pass ? ' not' : '') +
+            ' to have been triggered on ' + $pp(selector);
         } else {
-          return [
-            'Expected event ' + eventName + ' to have been triggered on ' + $pp(selector),
-            'Expected event ' + eventName + ' not to have been triggered on ' + $pp(selector)
-          ];
+          var actualArgs = jasmine.flight.events.eventArgs(selector, eventName, expectedArg);
+          return 'Expected event data ' + jasmine.pp(actualArgs[1]) + ' to match ' +
+            (fuzzyMatch ? '(fuzzy) ' : '') + jasmine.pp(expectedArg);
         }
       }();
 
@@ -437,17 +433,8 @@
                 return '<' + description.join(' ') + '>';
               };
 
-              if (wasTriggered) {
-                return [
-                  '<div class="value-mismatch">Expected event ' + eventName + ' to have been triggered on' + selector,
-                  '<div class="value-mismatch">Expected event ' + eventName + ' not to have been triggered on' + selector
-                ];
-              } else {
-                return [
-                  'Expected event ' + eventName + ' to have been triggered on ' + $pp(selector),
-                  'Expected event ' + eventName + ' not to have been triggered on ' + $pp(selector)
-                ];
-              }
+              return 'Expected event ' + eventName + (result.pass ? ' not' : '') +
+                ' to have been triggered on ' + $pp(selector);
             }();
 
             return result;


### PR DESCRIPTION
- Return single string instead of array (as expected by Jasmine 2.0)
- Provide useful feedback in triggeredOnAndWith when event was triggered
  but with wrong data
