### PR TITLE
Fix event spying example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ describeComponent('ui/text', function () {
     this.setupComponent({
       username: 'bob'
     });
-    expect(spyEvent).toHaveBeenTriggeredOnAndWith(document {
+    expect('data-username').toHaveBeenTriggeredOnAndWith(document, {
       username: 'bob'
     });
   });


### PR DESCRIPTION
Passing the event spy to `expect()` works when verifying a general behavior or result, such as with `toHaveBeenTriggered()`. However,it seems like the event name should be used instead when verifying behavior against an element, such as with `toHaveBeenTriggeredOn()` or `toHaveBeenTriggeredOnAndWith()`.

For reference:
https://github.com/velesin/jasmine-jquery#event-spies

This also corrects a typo with a missing comma in the example.

Thanks to @arkitex for helping to spot this.
